### PR TITLE
feat: add support for tracking last yoinked to send notifs

### DIFF
--- a/app/api/recent-activity/route.ts
+++ b/app/api/recent-activity/route.ts
@@ -1,4 +1,9 @@
 import { getRecentYoinks } from "../../../lib/contract";
+import {
+  getCurrentYoinker,
+  getNotificationTokenForAddress,
+  setCurrentYoinker,
+} from "../../../lib/kv";
 import { getYoinksWithUsernames } from "../../../lib/neynar";
 import { NextResponse } from "next/server";
 
@@ -12,12 +17,71 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {
+    const latest = await getCurrentYoinker();
     const recentYoinks = await getRecentYoinks(10);
+
+    const notifyYoinkers = recentYoinks.filter(
+      (y) => y.timestamp > (latest?.timestamp ?? 0),
+    );
+
+    let yoinksWithUsernames:
+      | {
+          from: string | undefined;
+          by: string | undefined;
+          timestamp: number;
+        }[]
+      | undefined;
+
     try {
-      const yoinksWithUsernames = await getYoinksWithUsernames(recentYoinks);
-      return NextResponse.json({ yoinksWithUsernames });
+      yoinksWithUsernames = await getYoinksWithUsernames(recentYoinks);
     } catch (error) {
       console.error("Error converting addresses to usernames:", error);
+    }
+
+    try {
+      if (latest && notifyYoinkers.length > 0) {
+        for (let i = 0; i < notifyYoinkers.length; i++) {
+          const yoinker = notifyYoinkers[i];
+          if (!yoinker) break;
+
+          await setCurrentYoinker(yoinker.by, yoinker.timestamp);
+          const notificationToken = await getNotificationTokenForAddress(
+            yoinker.from,
+          );
+          if (notificationToken) {
+            const fullyQualifiedYoinker = yoinksWithUsernames
+              ? (yoinksWithUsernames[i]?.by ?? "Someone")
+              : "Someone";
+            const response = await fetch(
+              "https://api.warpcast.com/v1/frame-notifications",
+              {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  notificationId: crypto.randomUUID(),
+                  title: "You've been Yoinked!",
+                  body: `${fullyQualifiedYoinker} yoinked the flag from you. Yoink it back!`,
+                  targetUrl: "https://yoink.party/framesV2/",
+                  tokens: [notificationToken],
+                }),
+              },
+            );
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error fetching recent activity:", error);
+      return NextResponse.json(
+        { error: "Failed to fetch recent activity" },
+        { status: 500 },
+      );
+    }
+
+    if (yoinksWithUsernames) {
+      return NextResponse.json({ yoinksWithUsernames });
+    } else {
       return NextResponse.json({ yoinksWithUsernames: recentYoinks });
     }
   } catch (error) {

--- a/app/framesV2/RecentActivity.tsx
+++ b/app/framesV2/RecentActivity.tsx
@@ -64,7 +64,7 @@ export function RecentActivity() {
   }
 
   return (
-    <div className="px-3">
+    <div className="px-3 w-full">
       <div className="text-xs">
         {yoinks.map((yoink, index) => (
           <div

--- a/app/framesV2/Yoink.tsx
+++ b/app/framesV2/Yoink.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
-import sdk from "@farcaster/frame-sdk";
+import sdk, { FrameNotificationDetails } from "@farcaster/frame-sdk";
 import { useChainId, useConnect, useSwitchChain } from "wagmi";
 import { revalidateFramesV2 } from "./actions";
 
@@ -194,6 +194,14 @@ function YoinkStart({
     }
   }, [account.address, router, txReceiptResult.isSuccess]);
 
+  const addFrame = useCallback(async () => {
+    try {
+      await sdk.actions.addFrame();
+    } catch (error) {
+      alert(`Error: ${error}`);
+    }
+  }, []);
+
   useEffect(() => {
     return () => {
       sdk.actions.setPrimaryButton({ text: "", hidden: true });
@@ -219,7 +227,7 @@ function YoinkStart({
   }
 
   return (
-    <div className="mt-6 p-3 flex-col items-center">
+    <div className="p-3 pt-9 flex flex-col items-center h-[100vh] justify-between">
       <div></div>
       <div className="pb-8 px-8 flex flex-col items-center">
         <div className="relative mb-1">
@@ -270,6 +278,8 @@ function YoinkStart({
         )}
       </div>
       <RecentActivity />
+      <div className="flex flex-col grow"></div>
+      <div className="rounded-lg text-sm font-semibold bg-slate-200 py-3 w-full text-center" onClick={addFrame}>Add Frame</div>
     </div>
   );
 }

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,0 +1,30 @@
+import { kv } from "@vercel/kv";
+
+type Yoinker = { address: string; timestamp: number };
+
+export const setCurrentYoinker = async (address: string, timestamp: number) => {
+  await kv.set<string>(
+    "current-yoinker",
+    JSON.stringify({ address, timestamp }),
+  );
+};
+
+export const getCurrentYoinker = async () => {
+  const current = await kv.get<string>("current-yoinker");
+  if (current != null) {
+    return JSON.parse(current) as Yoinker;
+  }
+
+  return null;
+};
+
+export const setNotificationTokenForAddress = async (
+  address: string,
+  token: string,
+) => {
+  await kv.set<string>("notification-" + address, token);
+};
+
+export const getNotificationTokenForAddress = async (address: string) => {
+  return await kv.get<string>("notification-" + address);
+};


### PR DESCRIPTION
# What changed?
Notification support for flag yoinking (via add frame). Requires additional Vercel KV config.

# Justification
Asking "who up yoinkin' they flag rn" is cool, but you know what's even cooler? Automatically telling your bros that you yoinked their flag, right then and there, in their notification inbox, giving them an opportunity to yoink your flag in kind.

# Notes
Uses the recurring fetch to initiate, so purely contractual yoinks stay incognito.

![IMG_1726](https://github.com/user-attachments/assets/e1086ec1-e24c-4957-b3eb-229b8b8a68cd)
